### PR TITLE
Develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ env:
 matrix:
   allow_failures:
     # CIM not available for CMUCL
-    # - env: LISP=cmucl
+    - env: LISP=cmucl
     # free edition --- heap exhausted
     # - env: LISP=allegro
-    # - env: LISP=abcl            # until lisp-namespace is updated
+    # - env: LISP=abcl
     # - env: LISP=clisp
     # - env: LISP=clisp32
-    # - env: LISP=ecl
+    - env: LISP=ecl
 
 # either use a local install.sh script or install it via curl. Feel
 # free to simplify this section in your own .travis.yml file.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+sudo: required
+language: lisp
+
+env:
+  matrix:
+    - LISP=abcl
+    - LISP=allegro
+    - LISP=sbcl
+    - LISP=sbcl32
+    - LISP=ccl
+    - LISP=ccl32
+    - LISP=clisp
+    - LISP=clisp32
+    - LISP=cmucl
+    - LISP=ecl
+
+matrix:
+  allow_failures:
+    # CIM not available for CMUCL
+    # - env: LISP=cmucl
+    # free edition --- heap exhausted
+    # - env: LISP=allegro
+    # - env: LISP=abcl            # until lisp-namespace is updated
+    # - env: LISP=clisp
+    # - env: LISP=clisp32
+    # - env: LISP=ecl
+
+# either use a local install.sh script or install it via curl. Feel
+# free to simplify this section in your own .travis.yml file.
+install:
+  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;
+    then
+      ./install.sh;
+    else
+      curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
+    fi     
+
+# this bit is just testing that travis correctly sets up ASDF to find
+# systems placed somewhere within ~/lisp. You can remove this section
+# in your own .travis.yml file.
+before_script:
+  - echo "(defsystem :dummy-cl-travis-system)" > ~/lisp/dummy-cl-travis-system.asd
+
+script:
+  - cl --load testscr.lisp

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Arrow-macros provides clojure-like arrow macros (ex. ->, ->>) and diamond wands in swiss-arrows (https://github.com/rplevy/swiss-arrows).
 
+[![Build Status](https://travis-ci.org/guicho271828/arrow-macros.svg?branch=master)](https://travis-ci.org/guicho271828/arrow-macros)
+
 ## Examples
 
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ These macro functions are equivalent to them too.
 
 ## Notes
 
+(June 2015)
+
+Build verified on sbcl, ccl, abcl, allegro, clisp.
+Failed on ecl while loading hu.dwim.walker.
+Not tested on cmucl.
+
 (May 7, 2015)
 
 On sbcl for windows, arrow-macros can be built now.

--- a/arrow-macros-test.asd
+++ b/arrow-macros-test.asd
@@ -16,5 +16,7 @@
   :license "MIT"
   :description "arrow-macros test"
   :depends-on (:fiveam :arrow-macros)
-  :components ((:file "arrow-macros-test")))
+  :components ((:file "arrow-macros-test"))
+  :perform (test-op (op c)
+             (eval (read-from-string "(fiveam::run! 'arrow-macros-test::all)"))))
 

--- a/arrow-macros.asd
+++ b/arrow-macros.asd
@@ -16,5 +16,6 @@
   :license "MIT"
   :description "arrow-macros provides clojure-like arrow macros and diamond wands."
   :depends-on (:hu.dwim.walker)
-  :components ((:file "arrow-macros")))
+  :components ((:file "arrow-macros"))
+  :in-order-to ((test-op (test-op :arrow-macros-test))))
 

--- a/arrow-macros.lisp
+++ b/arrow-macros.lisp
@@ -93,45 +93,6 @@
     #+sbcl(sb-kernel::arg-count-error () nil)
     #-sbcl(error () nil)))
 
-#|
-
-I strongly object to the inappropriate/implicit use of intern, which
-results in unhealthy macrology.
-
-Imagine a case where a diamond-wand is used in the expansion of another
-macro `mymacro', written by user1. He might export the macro as part of a library.
-
- (in-package :a)
- (use-package :arrow-macros)
- (defmacro mymacro (&body body)
-   `(-<> 42
-         (process-it <>) ;; interned, a::<>
-         ,@body))
- (export 'mymacro)
-
-Now, another lisper called user2 may use this macro
-without knowing that the diamond-wand is used in it.
-
- (in-package :b)
- (use-package :a)
-
- (defvar <> 'something)
-
- (mymacro (print <>))
-
-And the result is unexpected!
-
- -->
- (-<> 42
-      (process-it a::<>)
-      (print b::<>))
-
-It will be interpreted as (process-it a::<> b::<>) and signals an
-symbol-unbound error on a::<>.
-
-|#
-
-
 (defun diamond-wand (init exps env &optional spear-p some-p)
   (let ((gblock (gensym)))
     (if some-p

--- a/arrow-macros.lisp
+++ b/arrow-macros.lisp
@@ -18,7 +18,8 @@
            :-<>
            :-<>>
            :some-<>
-           :some-<>>))
+           :some-<>>
+           :<>))
 (in-package :arrow-macros)
 
 (defun arrow-macro (init exps &optional >>-p some-p)
@@ -68,7 +69,9 @@
 (defmacro cond-> (init &body exps) (cond-arrow-macro init exps))
 (defmacro cond->> (init &body exps) (cond-arrow-macro init exps t))
 
-(defun find-<>-variable-in-same-context% (form env)
+;; (define-symbol-macro <> (error "do not use <> outside the scope of diamond-wand macros!"))
+
+(defun has-diamond% (form env)
   (handler-bind ((hu.dwim.walker:walker-warning #'muffle-warning))
     (let* ((walked (hu.dwim.walker:walk-form
                     form
@@ -80,32 +83,73 @@
                          (hu.dwim.walker:collect-variable-references
                           walked
                           :type 'hu.dwim.walker:unwalked-lexical-variable-reference-form))))
-      (find (intern "<>") (mapcar #'hu.dwim.walker:name-of refs)))))
+      (find '<> (mapcar #'hu.dwim.walker:name-of refs)))))
 
-(defun find-<>-variable-in-same-context (form env)
-    (handler-case (find-<>-variable-in-same-context% form env)
-      #+sbcl(sb-kernel::arg-count-error () nil)
-      #-sbcl(error () nil)))
+(defun has-diamond (form env)
+  "Return true when the form uses <> as a variable reference."
+  ;; Note that simple tree parsing does not work for the cases like
+  ;; (let ((<> ...)) ...)
+  (handler-case (has-diamond% form env)
+    #+sbcl(sb-kernel::arg-count-error () nil)
+    #-sbcl(error () nil)))
+
+#|
+
+I strongly object to the inappropriate/implicit use of intern, which
+results in unhealthy macrology.
+
+Imagine a case where a diamond-wand is used in the expansion of another
+macro `mymacro', written by user1. He might export the macro as part of a library.
+
+ (in-package :a)
+ (use-package :arrow-macros)
+ (defmacro mymacro (&body body)
+   `(-<> 42
+         (process-it <>) ;; interned, a::<>
+         ,@body))
+ (export 'mymacro)
+
+Now, another lisper called user2 may use this macro
+without knowing that the diamond-wand is used in it.
+
+ (in-package :b)
+ (use-package :a)
+
+ (defvar <> 'something)
+
+ (mymacro (print <>))
+
+And the result is unexpected!
+
+ -->
+ (-<> 42
+      (process-it a::<>)
+      (print b::<>))
+
+It will be interpreted as (process-it a::<> b::<>) and signals an
+symbol-unbound error on a::<>.
+
+|#
+
 
 (defun diamond-wand (init exps env &optional spear-p some-p)
-  (symbol-macrolet ((<> (intern "<>")))
-    (let ((gblock (gensym)))
-      (if some-p
-          `(block ,gblock
-             (let ((,<> (or ,init (return-from ,gblock nil))))
+  (let ((gblock (gensym)))
+    (if some-p
+        `(block ,gblock
+           (let ((<> (or ,init (return-from ,gblock nil))))
                ,@(loop for (exp next-exp) on exps collect
-                      (let ((exp (cond ((find-<>-variable-in-same-context exp env) exp)
-                                       (spear-p `(->> ,<> ,exp))
-                                       (t `(-> ,<> ,exp)))))
-                        (if next-exp
-                            `(setf ,<> (or ,exp (return-from ,gblock nil)))
+                 (let ((exp (cond ((has-diamond exp env) exp)
+                                  (spear-p `(->> <> ,exp))
+                                  (t `(-> <> ,exp)))))
+                   (if next-exp
+                       `(setf <> (or ,exp (return-from ,gblock nil)))
                             exp)))))
-          `(let ((,<> ,init))
-             ,@(loop for (exp next-exp) on exps collect
-                    (let ((exp (cond ((find-<>-variable-in-same-context exp env) exp)
-                                     (spear-p `(->> ,<> ,exp))
-                                     (t `(-> ,<> ,exp)))))
-                      (if next-exp `(setf ,<> ,exp) exp))))))))
+        `(let ((<> ,init))
+           ,@(loop for (exp next-exp) on exps collect
+               (let ((exp (cond ((has-diamond exp env) exp)
+                                (spear-p `(->> <> ,exp))
+                                (t `(-> <> ,exp)))))
+                 (if next-exp `(setf <> ,exp) exp)))))))
 
 (defmacro -<> (init &body exps &environment env) (diamond-wand init exps env))
 (defmacro -<>> (init &body exps &environment env) (diamond-wand init exps env t))

--- a/testscr.lisp
+++ b/testscr.lisp
@@ -1,0 +1,19 @@
+
+(in-package :cl-user)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (ql:quickload :fiveam))
+
+(defun test (sys)
+  (handler-case
+      (progn
+        (ql:quickload sys)
+        (asdf:load-system sys)
+        (eval (read-from-string "(fiveam:run! 'arrow-macros-test::all)")))
+    (serious-condition (c)
+      (describe c)
+      (uiop:quit 2))))
+
+(uiop:quit (if (every #'fiveam::TEST-PASSED-P
+                      (test :arrow-macros))
+               0 1))

--- a/testscr.lisp
+++ b/testscr.lisp
@@ -2,18 +2,12 @@
 (in-package :cl-user)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (ql:quickload :fiveam))
-
-(defun test (sys)
-  (handler-case
-      (progn
-        (ql:quickload sys)
-        (asdf:load-system sys)
-        (eval (read-from-string "(fiveam:run! 'arrow-macros-test::all)")))
-    (serious-condition (c)
-      (describe c)
-      (uiop:quit 2))))
+  (ql:quickload :arrow-macros-test))
 
 (uiop:quit (if (every #'fiveam::TEST-PASSED-P
-                      (test :arrow-macros))
+                      (handler-case
+                          (fiveam:run! 'arrow-macros-test::all)
+                        (serious-condition (c)
+                          (describe c)
+                          (uiop:quit 2))))
                0 1))


### PR DESCRIPTION
I strongly object to the inappropriate/implicit use of intern, which
results in unhealthy macrology.

Imagine a case where a diamond-wand is used in the expansion of another
macro `mymacro', written by user1. He might export the macro as part of a library.

```
(in-package :a)
(use-package :arrow-macros)
(defmacro mymacro (&body body)
  `(-<> 42
        (process-it <>) ;; interned, a::<>
        ,@body))
(export 'mymacro)
```

Now, another lisper called user2 may use this macro
without knowing that the diamond-wand is used in it.

```
(in-package :b)
(use-package :a)

(defvar <> 'something)

(mymacro (print <>))
```

And the result is unexpected!

```
-->
(-<> 42
     (process-it a::<>)
     (print b::<>))
```

It will be interpreted as `(process-it a::<> b::<>)` because the walker fails to find `b::<>` in the form `(process-it a::<>)` and append an implicit `b::<>`. Then it signals an symbol-unbound error on `a::<>`.

Tests passed on my side, sbcl64 1.2.8, but we should wait for the comprehensive testing results on travis-ci.
