### PR TITLE
Remove Alexandria dependency.

### DIFF
--- a/arrow-macros.asd
+++ b/arrow-macros.asd
@@ -15,6 +15,6 @@
   :author "hipeta"
   :license "MIT"
   :description "arrow-macros provides clojure-like arrow macros and diamond wands."
-  :depends-on (:alexandria)
+  :depends-on ()
   :components ((:file "arrow-macros"))
   :in-order-to ((test-op (test-op :arrow-macros-test))))

--- a/arrow-macros.lisp
+++ b/arrow-macros.lisp
@@ -77,7 +77,7 @@
 
 (defun has-diamond (exp)
   (labels ((rec (exp)
-             (cond ((eq exp '<>) t)
+             (cond ((eq exp '<>) (return-from has-diamond t))
 
                    ; inner diamond wand can refer to outer <> symbol only in initial form
                    ((and (listp exp) (diamond-wand-symbol-p (car exp)))
@@ -85,8 +85,8 @@
                    
                    ((listp exp) (mapcar #'rec exp))
                    (t nil))))
-    (let ((fexp (alexandria:flatten (rec exp))))
-      (and fexp (reduce (lambda (a b) (or a b)) fexp)))))
+    (rec exp)
+    nil))
 
 (defun replace-diamond (exp diamond-exp)
   (cond ((eq exp '<>) diamond-exp)


### PR DESCRIPTION
Hi! 

I've started using your library in my default CL setup, but Alexandria dependency was weighting on me. Looking through the source, I found that Alexandria is only used once, in the function that could've well worked without it. So I rewritten the part with Alexandria to be a more immediate (and slightly faster) computation.